### PR TITLE
Support new policy_dir input to use embedded policies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/ksoc-public/policy-executor:v0.0.7
+FROM us.gcr.io/ksoc-public/policy-executor:v0.0.8
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 KSOC finds misconfigurations in your Kubernetes posture as part of your GitHub Actions CI workflow.
 
-This action is used to execute a set of KSOC policies against the Kubernetes manifests in a given repository. It is used in the following way:
+This action is used to execute a set of KSOC policies against the Kubernetes manifests in a given repository. There are two sources of policies that can be used:
+
+- Policies fetched from your KSOC account. This requires the `ksoc_account_id`, `ksoc_access_key_id` and `ksoc_secret_key` inputs to be provided.
+- Policies from the `policies` directory embedded in this action. This requires the `policy_dir` input to be provided with `policies` value.
+
+## Example Usage With Policies From KSOC Account
 
 ```yaml
 name: ksoc-guard
@@ -19,14 +24,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: KSOC Guard
-        uses: ksoclabs/guard-action@v0.0.6
+        uses: ksoclabs/guard-action@v0.0.7
         with:
           ksoc_account_id: <KSOC_ACCOUNT_ID>
           ksoc_access_key_id: ${{ secrets.KSOC_ACCESS_KEY_ID }}
           ksoc_secret_key: ${{ secrets.KSOC_SECRET_KEY }}
 ```
 
-The `ksoc_access_key_id` and `ksoc_secret_key` are the credentials for the KSOC account that will be used to fetch the policies and should be stored as GitHub secrets. The `ksoc_account_id` must match the KSOC account that the credentials are for.
+## Example Usage With Policies From Repository
+
+```yaml
+name: ksoc-guard
+
+on:
+  pull_request:
+
+jobs:
+  ksoc-guard:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: KSOC Guard
+        uses: ksoclabs/guard-action@v0.0.7
+        with:
+          policy_dir: policies
+```
+
+## Optional Inputs
 
 There are numerous optional inputs that can be used to configure the action:
 - `fail_on_severity`: The severity level that will cause the action to fail. If not provided, the action will never fail.
@@ -36,6 +63,8 @@ There are numerous optional inputs that can be used to configure the action:
 - `paths`: A comma separated list of paths to scan. If not provided, all paths in the repository will be scanned.
 - `policy_ids`: A comma separated list of policy IDs to execute. If not provided, all policies in the KSOC account will be executed.
 - `policy_tags`: A comma separated list of policy tags to execute. If not provided, all policies in the KSOC account will be executed.
+
+## Outputs
 
 KSOC Guard Action is storing the results of the scan in the output called `results`. This can be used to create a comment on the PR with the results of the scan. The following example shows how to do this (note that `pull-resuests` permission is required for this):
 
@@ -55,7 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: KSOC Guard
-        uses: ksoclabs/guard-action@v0.0.6
+        uses: ksoclabs/guard-action@v0.0.7
         with:
           ksoc_account_id: <KSOC_ACCOUNT_ID>
           ksoc_access_key_id: ${{ secrets.KSOC_ACCESS_KEY_ID }}
@@ -81,3 +110,25 @@ jobs:
               body: output
             })
 ```
+
+## Embedded Policies
+
+The following policies are embedded in this action if used with the `policy_dir` input:
+
+| Policy ID                       | Policy Title                                                   | Severity |
+|---------------------------------|----------------------------------------------------------------|----------|
+| KSOC-K8S-RUN-AS-HIGH-UID        | Container(s) not running with a high UID                       | low      |
+| KSOC-K8S-PRIV-ESC               | Container(s) allow privilege escalation                        | medium   |
+| KSOC-K8S-IMAGE-LATEST           | Container(s) image tag is set to latest                        | low      |
+| KSOC-K8S-CAP-SYSADMIN           | CAP_SYS_ADMIN Linux capability is in use in container(s)       | high     |
+| KSOC-K8S-HOST-PID               | Host PID flag set to true in container(s)                      | low      |
+| KSOC-K8S-HOST-IPC               | hostIPC flag set to true in container(s)                       | low      |
+| KSOC-K8S-HOST-NETWORK           | hostNetwork flag set to true                                   | low      |
+| KSOC-K8S-NET-RAW                | NET_RAW capability detected in container(s)                    | medium   |
+| KSOC-K8S-ROLE-CLUSTERADMIN      | Ensure that the cluster-admin role is only used where required | high     |
+| KSOC-K8S-WILDCARD-APIGROUPS     | Minimize wildcard use in Roles and ClusterRoles:ApiGroups      | medium   |
+| KSOC-K8S-WILDCARD-RESOURCES     | Minimize wildcard use in Roles and ClusterRoles:Resources      | medium   |
+| KSOC-K8S-WILDCARD-VERBS         | Minimize wildcard use in Roles and ClusterRoles:Verbs          | medium   |
+| KSOC-K8S-DEFAULT-SERVICEACCOUNT | Ensure that default service accounts are not actively used.    | medium   |
+| KSOC-K8S-SECURITYCONTEXT        | Container(s) running without defined securityContext           | medium   |
+| KSOC-K8S-SECURITYCONTEXT-POD    | Pod running without defined securityContext                    | medium   |

--- a/action.yml
+++ b/action.yml
@@ -17,36 +17,35 @@ inputs:
   ignored_paths:
     required: false
     description: "Comma separated list of paths to ignore."
-    default: ""
   ignored_policies:
     required: false
     description: "Comma separated list of policy IDs to ignore."
-    default: ""
   ksoc_access_key_id:
+    required: false
     description: "The KSOC access key ID."
-    required: true
   ksoc_account_id:
+    required: false
     description: "The KSOC account ID."
-    required: true
   ksoc_api_url:
     required: false
     description: "The KSOC API URL."
     default: https://api.ksoc.com
   ksoc_secret_key:
+    required: false
     description: "The KSOC secret key."
-    required: true
   paths:
     required: false
     description: "Comma separated list of paths to scan."
     default: "."
+  policy_dir:
+    required: false
+    description: "The directory containing the policies to execute."
   policy_ids:
     required: false
     description: "Comma separated list of policy IDs to execute."
-    default: ""
   policy_tags:
     required: false
     description: "Comma separated list of policy tags to execute."
-    default: ""
 outputs:
   results:
     description: "The results of the policy execution."
@@ -64,5 +63,6 @@ runs:
     KSOC_API_URL: ${{ inputs.ksoc_api_url }}
     KSOC_SECRET_KEY: ${{ inputs.ksoc_secret_key }}
     PATHS: ${{ inputs.paths }}
+    POLICY_DIR: ${{ inputs.policy_dir }}
     POLICY_IDS: ${{ inputs.policy_ids }}
     POLICY_TAGS: ${{ inputs.policy_tags }}


### PR DESCRIPTION
New version of `policy-executor` has 15 policies embedded which is a good starting point to try this GH Action without KSOC account.