### PR TITLE
Support for SARIF output format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/ksoc-public/policy-executor:v0.0.9
+FROM us.gcr.io/ksoc-public/policy-executor:v0.0.11
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,8 @@ inputs:
 outputs:
   results:
     description: "The results of the policy execution."
+  sarif:
+    description: "Path to a SARIF report file with the policy execution results."
 
 runs:
   using: docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh -l
 
 EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-echo "results<<$EOF" >> $GITHUB_OUTPUT
-/app/policy-executor policies execute >> $GITHUB_OUTPUT
-exit_code=$?
-echo "$EOF" >> $GITHUB_OUTPUT
-cat $GITHUB_OUTPUT
+if [ $FORMAT = "sarif" ]; then
+  SARIF_OUTPUT_FILE_NAME="./report.sarif"
+  /app/policy-executor policies execute > $SARIF_OUTPUT_FILE_NAME
+  exit_code=$?
+  echo "sarif=$SARIF_OUTPUT_FILE_NAME" >> $GITHUB_OUTPUT
+else
+  echo "results<<$EOF" >> $GITHUB_OUTPUT
+  /app/policy-executor policies execute >> $GITHUB_OUTPUT
+  exit_code=$?
+  echo "$EOF" >> $GITHUB_OUTPUT
+fi
 exit $exit_code


### PR DESCRIPTION
This change allows to use SARIF output format which can be uploaded to GitHub Security.

<img width="947" alt="image" src="https://user-images.githubusercontent.com/271001/237043363-57510cb1-7ab7-4554-be40-0feb651ada02.png">
