### PR TITLE
Print results to stdout by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/ksoc-public/policy-executor:v0.0.11
+FROM us.gcr.io/ksoc-public/policy-executor:v0.0.12
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: KSOC Guard
-        uses: ksoclabs/guard-action@v0.0.9
+        uses: ksoclabs/guard-action@v0.0.10
         with:
           ksoc_account_id: <KSOC_ACCOUNT_ID>
           ksoc_access_key_id: ${{ secrets.KSOC_ACCESS_KEY_ID }}
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: KSOC Guard
-        uses: ksoclabs/guard-action@v0.0.9
+        uses: ksoclabs/guard-action@v0.0.10
         with:
           policy_dir: /policies
 ```
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v3
       - name: KSOC Guard
         id: ksoc-guard
-        uses: ksoclabs/guard-action@v0.0.9
+        uses: ksoclabs/guard-action@v0.0.10
         with:
           ksoc_account_id: <KSOC_ACCOUNT_ID>
           ksoc_access_key_id: ${{ secrets.KSOC_ACCESS_KEY_ID }}
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v3
       - name: KSOC Guard
         id: ksoc-guard
-        uses: ksoclabs/guard-action@v0.0.9
+        uses: ksoclabs/guard-action@v0.0.10
         with:
           fail_on_severity: low
           format: sarif

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   fail_on_severity:
     required: false
     description: "The severity level at which to fail the workflow. Valid values are: none, low, medium, high, critical."
-    default: high
+    default: none
   format:
     required: false
     description: "The format of the output. Valid values are: ci-table, table."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,16 @@
 #!/bin/sh -l
 
-EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 if [ $FORMAT = "sarif" ]; then
   SARIF_OUTPUT_FILE_NAME="./report.sarif"
   /app/policy-executor policies execute > $SARIF_OUTPUT_FILE_NAME
   exit_code=$?
   echo "sarif=$SARIF_OUTPUT_FILE_NAME" >> $GITHUB_OUTPUT
 else
+  EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
   echo "results<<$EOF" >> $GITHUB_OUTPUT
   /app/policy-executor policies execute >> $GITHUB_OUTPUT
   exit_code=$?
   echo "$EOF" >> $GITHUB_OUTPUT
+  grep -v "$EOF" $GITHUB_OUTPUT
 fi
 exit $exit_code


### PR DESCRIPTION
Also, fix action input `fail_on_severity` default value to be according to documentation and use most recent policy-executor image that contains a fix for SARIF output when there are no results.